### PR TITLE
Update operations.py

### DIFF
--- a/kinetic/operations.py
+++ b/kinetic/operations.py
@@ -170,7 +170,7 @@ class GetPrevious(object):
 class GetKeyRange(object):
 
     @staticmethod
-    def build(startKey, endKey, startKeyInclusive=True, endKeyInclusive=True, maxReturned=256):
+    def build(startKey, endKey, startKeyInclusive=True, endKeyInclusive=True, maxReturned=200):
         if len(startKey) > common.MAX_KEY_SIZE: raise common.KineticClientException("Start key exceeds maximum size of {0} bytes.".format(common.MAX_KEY_SIZE))
         if len(endKey) > common.MAX_KEY_SIZE: raise common.KineticClientException("End key exceeds maximum size of {0} bytes.".format(common.MAX_KEY_SIZE))
 


### PR DESCRIPTION
Lowered maxReturned to within new thresholds. Should fix ASKOVAD-287.

Nacho, I reduced maxReturned to 200, which is the highest I can get it to go on my 2.0.1 drives without the drive returning the INVALID_REQUEST.
