### PR TITLE
Changed the proto compiler script to pull from the bleeding edge .proto

### DIFF
--- a/compile_proto.sh
+++ b/compile_proto.sh
@@ -2,7 +2,8 @@
 
 BASE_DIR=$(cd "$(dirname "$0")"; pwd)
 PROTO_DIR=/tmp/kinetic-protocol
-PROTO=https://raw.githubusercontent.com/Seagate/kinetic-protocol/9c6b4a180a70f8488c5d8ec8e8a6464c4ff63f84/kinetic.proto
+PROTO=https://raw.githubusercontent.com/Seagate/kinetic-protocol/master/kinetic.proto
+#PROTO=https://raw.githubusercontent.com/Seagate/kinetic-protocol/9c6b4a180a70f8488c5d8ec8e8a6464c4ff63f84/kinetic.proto
 
 mkdir $PROTO_DIR
 wget $PROTO -O $PROTO_DIR/kinetic.proto


### PR DESCRIPTION
Set the compile_proto.sh to pull from the bleeding edge kinetic.proto. Is there any reason not to do this? I'd like to change this so we can pull a new enough .proto to add the FLUSHALL in the client.
