### PR TITLE
Update operations.py

### DIFF
--- a/kinetic/operations.py
+++ b/kinetic/operations.py
@@ -326,7 +326,7 @@ class PushKeys(object):
 class Flush(object):
 
     @staticmethod
-    def build(types):
+    def build():
         m = messages.Message()
         m.command.header.messageType = messages.Message.FLUSHALLDATA
 


### PR DESCRIPTION
Argument "types" for building the FLUSHALLDATA operation wasn't used, and I don't think philosophically flush should need an argument, right?

Nacho: Does the flush command really need an argument? It looks as though it was unused, and would probably make more sense (from a user perspective) to eliminate it. Thoughts?
