### PR TITLE
Update baseclient.py

### DIFF
--- a/kinetic/baseclient.py
+++ b/kinetic/baseclient.py
@@ -248,7 +248,7 @@ class BaseClient(object):
         magic, proto_ln, value_ln = struct.unpack_from(">bii", buffer(msg))
 
         if magic!= 70:
-            LOG.warn("Magic number = {0}".format(self.bytearray_to_hex(buff)))
+            LOG.warn("Magic number = {0}".format(self.bytearray_to_hex(magic)))
             raise common.KineticClientException("Invalid Magic Value!") # 70 = 'F'
 
         # read proto message


### PR DESCRIPTION
Fixed code bug with magic number.

Nacho, I think this (possibly) addresses ASOKVAD-313, which would indicate that the problem is not so much with the client library as something else. If nothing else, this should fix the minor bug in that buff was not defined in _recv_delimited_v2 and it looks like you meant magic instead.
