### PR TITLE
Update operations.py

### DIFF
--- a/kinetic/operations.py
+++ b/kinetic/operations.py
@@ -381,9 +381,9 @@ class GetLog(object):
 
     @staticmethod
     def onError(e):
-        if isinstance(e,KineticMessageException):
-            if e.code and e.code == 'NOT_FOUND':
-                return None
+        #if isinstance(e,KineticMessageException):
+        #    if e.code and e.code == 'NOT_FOUND':
+        #        return None
         raise e
 
 class Setup(object):


### PR DESCRIPTION
Removed the error handling on GetLog for NOT_FOUND (return None on NOT_FOUND), as I don't think you expect this to normally occur the same way it would for a regular get (i.e. it may be intuitive for get to return None if no associated key was found, but it isn't quite as intuitive for the getLog command to return None if the drive faults on getting a log and returns not found).

This should partially address issue #15. This is also partially a drive issue.
