### PR TITLE
Update baseclient.py

### DIFF
--- a/kinetic/baseclient.py
+++ b/kinetic/baseclient.py
@@ -149,7 +149,8 @@ class BaseClient(object):
             try:
                 self._socket.shutdown(socket.SHUT_RDWR)
                 self._socket.close()
-            except: pass # if socket wasnt connected, keep going
+            except Exception as e: 
+                LOG.warning('Socket faulted on shutdown/close for {}.'.format(e))
         self._buff = ''
         self._socket = None
         self.connection_id = None


### PR DESCRIPTION
Reliability has seen some sockets not get shutdown correctly when investigating magic number faults. The client code gives no indication that we faulted on shutdown/close, but we should probably alert the user if we weren't able to close the socket in a clean fashion. This change should address that.

---

Nacho, it looks like some of the sockets weren't getting closed gracefully in some of the reliability failures when looking at the drive side logs. The base client was previously silently suppressing the faults on close/shutdown, and I would like it to at least log that it had a failure, and what it was. This is what this change should address. What do you think?
