### PR TITLE
Add MANIFEST.in for sdist tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt


### PR DESCRIPTION
When I `python setup.py sdist` I'm getting a broken source tarball because `setup.py` makes reference to the `requirements.txt` file which isn't included in the source distribution by default.  It would greatly simplify my build infrastructure if the source tarball that gets kicked out by `setup.py` could be used to build distro packages unmodified.

It seems the most common way to handle this issue is to define a `MANIFEST.in` to use as a template for extra files that need to be included in the source tarball [1].  AFIK, `MANIFEST.in` only effects output of `sdist` and doesn't seem to actually include any extra any of the `bdist` outputs.  For example, the `./package.sh` script built a `kinetic-0.8.1-py2.7.egg`; which OMM didn't include the `requirements.txt` file (which makes sense, the requirements.txt file should only be a build requirement).

1. https://docs.python.org/2/distutils/sourcedist.html#specifying-the-files-to-distribute